### PR TITLE
Feat4 battle leader

### DIFF
--- a/client/pages/battles.jsx
+++ b/client/pages/battles.jsx
@@ -140,9 +140,9 @@ export default class Battles extends React.Component {
       <div className="container">
         <div className="row justify-content-center">
           <div className="col-md-8 text-center">
-            <div className="card">
+            <div className="card m-2">
               <div className='container text-center'>
-                <img src={this.state.opponent.leader.leaderPic} className="" alt={`${this.state.opponent.leader.leaderName} Picture`} />
+                <img src={this.state.opponent.leader.leaderPic} className="small-img" alt={`${this.state.opponent.leader.leaderName} Picture`} />
               </div>
               <div className="card-body">
                 <h5 className="card-title">{this.state.opponent.leader.leaderName}</h5>
@@ -157,15 +157,17 @@ export default class Battles extends React.Component {
             </div>
           </div>
         </div>
-        <div className="row">
-          <div className="card">
-            <img src={this.state.user.pkmn.sprite} className="card-img-top" alt={`${this.state.user.pkmn.pkmnName} Picture`} />
-            <div className="card-body text-center">
-              <h5 className="card-title">{this.state.user.pkmn.pkmnName}</h5>
-              <div className="btn-group btn-group-lg" role="group" aria-label="Basic mixed styles example">
-                <button type="button" className="btn btn-success" onClick={this.onMoveSelectHandler}>Physical: {this.state.user.pkmn.physicalMove}</button>
-                <button type="button" className="btn btn-danger" onClick={this.onMoveSelectHandler}>Special: {this.state.user.pkmn.specialMove}</button>
-                <button type="button" className="btn btn-warning" onClick={this.onMoveSelectHandler}>Status: {this.state.user.pkmn.statusMove}</button>
+        <div className="row justify-content-center">
+          <div className="col-md-8 text-center">
+            <div className="card m-2">
+              <div className="card-body text-center">
+                <img src={this.state.user.pkmn.sprite} className="small-img" alt={`${this.state.user.pkmn.pkmnName} Picture`} />
+                <p className="card-title">Your Pok&eacute;mon: <strong>{this.state.user.pkmn.pkmnName}</strong></p>
+                <div className="btn-group btn-group-lg" role="group" aria-label="Basic mixed styles example">
+                  <button type="button" className="btn btn-success" onClick={this.onMoveSelectHandler}>Physical: {this.state.user.pkmn.physicalMove}</button>
+                  <button type="button" className="btn btn-danger" onClick={this.onMoveSelectHandler}>Special: {this.state.user.pkmn.specialMove}</button>
+                  <button type="button" className="btn btn-warning" onClick={this.onMoveSelectHandler}>Status: {this.state.user.pkmn.statusMove}</button>
+                </div>
               </div>
             </div>
           </div>

--- a/client/pages/battles.jsx
+++ b/client/pages/battles.jsx
@@ -42,10 +42,19 @@ export default class Battles extends React.Component {
           sprite: '',
           statusMove: ''
         }
-      }
+      },
+      battleResult: '',
+      params: {},
+      battleStatus: ''
     };
 
     this.onMoveSelectHandler = this.onMoveSelectHandler.bind(this);
+    this.battleHandler = this.battleHandler.bind(this);
+    this.battleUpdater = this.battleUpdater.bind(this);
+
+    this.resultModal = new bootstrap.Modal('#battleResult', {
+      keyboard: false
+    });
   }
 
   componentDidMount() {
@@ -119,17 +128,115 @@ export default class Battles extends React.Component {
       user: {
         ...oldUser,
         userId: newParams.userPkmn
-      }
+      },
+      params: newParams,
+      battleStatus: 'in progress'
     });
+  }
+
+  battleUpdater(result) {
+    const battleData = {
+      recordId: this.state.params.recordId,
+      battleResult: result
+    };
+    fetch('/api/battles/result', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(battleData)
+    })
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Something went wrong.');
+        } else {
+          return res.json();
+        }
+      })
+      .then(record => {
+        this.setState({
+          battleStatus: 'complete'
+        });
+      })
+      .catch(err => console.error(err));
+  }
+
+  battleHandler(userMove) {
+    function getRandomIntInclusive(min, max) {
+      min = Math.ceil(min);
+      max = Math.floor(max);
+      return Math.floor(Math.random() * (max - min + 1) + min); // The maximum is inclusive and the minimum is inclusive
+    }
+
+    const leaderMove = getRandomIntInclusive(1, 3);
+
+    if (leaderMove === 1) {
+      if (userMove === 1) {
+        this.setState({
+          battleResult: 'tie'
+        });
+        this.resultModal.show();
+      }
+      if (userMove === 2) {
+        this.setState({
+          battleResult: 'win'
+        });
+        this.battleUpdater('win');
+      }
+      if (userMove === 3) {
+        this.setState({
+          battleResult: 'loss'
+        });
+        this.battleUpdater('loss');
+      }
+    } else if (leaderMove === 2) {
+      if (userMove === 2) {
+        this.setState({
+          battleResult: 'tie'
+        });
+        this.resultModal.show();
+      }
+      if (userMove === 3) {
+        this.setState({
+          battleResult: 'win'
+        });
+        this.battleUpdater('win');
+      }
+      if (userMove === 1) {
+        this.setState({
+          battleResult: 'loss'
+        });
+        this.battleUpdater('loss');
+      }
+    } else if (leaderMove === 3) {
+      if (userMove === 3) {
+        this.setState({
+          battleResult: 'tie'
+        });
+        this.resultModal.show();
+      }
+      if (userMove === 1) {
+        this.setState({
+          battleResult: 'win'
+        });
+        this.battleUpdater('win');
+      }
+      if (userMove === 2) {
+        this.setState({
+          battleResult: 'loss'
+        });
+        this.battleUpdater('loss');
+      }
+    }
   }
 
   onMoveSelectHandler(event) {
     if (event.target.className === 'btn btn-success') {
-      alert(event.target.textContent);
+      this.battleHandler(1);
     } else if (event.target.className === 'btn btn-danger') {
-      alert(event.target.textContent);
+      this.battleHandler(2);
     } else if (event.target.className === 'btn btn-warning') {
-      alert(event.target.textContent);
+      this.battleHandler(3);
     }
 
     event.preventDefault();
@@ -168,6 +275,23 @@ export default class Battles extends React.Component {
                   <button type="button" className="btn btn-danger" onClick={this.onMoveSelectHandler}>Special: {this.state.user.pkmn.specialMove}</button>
                   <button type="button" className="btn btn-warning" onClick={this.onMoveSelectHandler}>Status: {this.state.user.pkmn.statusMove}</button>
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="modal fade" id="battleResult" data-bs-backdrop="static" data-bs-keyboard="false" tabIndex="-1" aria-labelledby="battleResultLabel" aria-hidden="true">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h1 className="modal-title fs-5" id="battleResultLabel">Modal title</h1>
+                <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+              </div>
+              <div className="modal-body">
+                Battle result: {this.state.battleResult}
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                {(this.state.battleResult === 'tie') ? <button type="button" className="btn btn-primary">Try Again</button> : <button type="button" className="btn btn-primary">Understood</button>}
               </div>
             </div>
           </div>

--- a/server/index.js
+++ b/server/index.js
@@ -125,6 +125,34 @@ app.get('/api/leader-list/:id', (req, res, next) => {
     .catch(err => next(err));
 });
 
+// GET: get status of a battle for a record ID
+
+app.post('/api/battles/status/:id', (req, res, next) => {
+  const id = req.params.id;
+  if (!id) {
+    throw new ClientError(400, 'id is required');
+  }
+
+  const sql = `
+    SELECT "result"
+    FROM "recordList"
+    WHERE "recordId" = $1
+  `;
+  const params = [id];
+  db.query(sql, params)
+    .then(result => {
+      if (!result.rows[0]) {
+        throw new ClientError(400, 'Something went wrong');
+      } else {
+        return result.rows[0];
+      }
+    })
+    .then(record => {
+      res.status(201).json(record);
+    })
+    .catch(err => next(err));
+});
+
 // POST: create a battle for a record ID
 
 app.post('/api/battles/new', (req, res, next) => {

--- a/server/public/styles.css
+++ b/server/public/styles.css
@@ -1,3 +1,7 @@
 .pkmn-leader-img {
   max-height: 100px;
 }
+
+.small-img {
+  max-width: 20%;
+}


### PR DESCRIPTION
![feat4](https://user-images.githubusercontent.com/75236087/201605648-17b334d0-134d-46d6-b642-13aa1fd767d4.gif)

still using localstorage for the time being, handles wins, losses, and ties in local for now. 

only one escape issue with pathing out of the battle screen instead of using a button. I just will handle it with persistent userdata instead of hardcoded interaction guardrails.